### PR TITLE
Add default preflight and disable link decoration

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,6 +5,9 @@
 body {
   font-family: Arial, Helvetica, sans-serif;
 }
+a {
+  text-decoration:none;
+}
 
 @layer utilities {
   .text-balance {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,6 +8,9 @@ const config: Config = {
 		"./app/**/*.{js,ts,jsx,tsx,mdx}",
 		"*.{js,ts,jsx,tsx,mdx}"
 	],
+	corePlugins: {
+		preflight: false,
+	},
 	theme: {
 		extend: {
 			colors: {


### PR DESCRIPTION
mdx's style for tags such as h1,h2 is not availble without preflight.
Alongside with preflight change, a tag's decration is set to none.