### PR TITLE
Added cover image area and author area

### DIFF
--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -6,6 +6,9 @@ import PageHeader from '@/components/page-header'
 import { ExternalLink } from 'lucide-react'
 import { cookies } from 'next/headers'
 import { Locale, defaultLocale, translate } from "@/lib/i18n"
+import Image from "next/image";
+import React from "react";
+import {SpeakerAvatar} from "@/components/SpeakerAvatar";
 
 export const metadata: Metadata = {
     title: 'Articles',
@@ -31,6 +34,14 @@ export default function ArticlesPage() {
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
                     {articles.map((item) => (
                         <div key={item.id} className="bg-gray-900 p-6 rounded-lg">
+                            <div className="relative w-full h-40 mb-4 overflow-hidden rounded">
+                            <Image
+                                src={item.coverImage}
+                                alt={item.title}
+                                fill
+                                className="object-cover"
+                            />
+                            </div>
                             <Link
                                 href={item.url}
                                 target="_blank"
@@ -42,6 +53,28 @@ export default function ArticlesPage() {
                             <p className="text-gray-300 text-sm mb-4">{item.description}</p>
                             <div className="flex flex-col gap-3">
                                 <div className="flex items-center text-gray-400 text-sm">
+                                    {/* Author display */}
+                                    {item.author && (() => { // Use an IIFE (Immediately Invoked Function Expression)
+                                        // Calculate slug based on the author string
+                                        const authorSlug = item.author.toLowerCase()
+                                            .replace(/\s+/g, '-') // Replace spaces with hyphens
+                                            .replace(/^e\.\s+/, '') // Remove "e. " prefix
+                                            .replace(/^dr\.\s+/, '') // Remove "dr. " prefix
+                                            .replace(/^prof\.\s+/, '') // Remove "prof. " prefix
+                                            .replace(/['"]/g, ''); // Remove quotes
+
+                                        const imageSource = `/images/speakers/${authorSlug}.png`;
+
+                                        return (
+                                                <div className="flex -space-x-2 overflow-hidden">
+                                                    <SpeakerAvatar
+                                                        key={item.id}
+                                                        src={imageSource}
+                                                        alt={item.author} // Use the author's name string for alt text
+                                                    />
+                                                </div>
+                                        );
+                                    })()}
                                     <span>{item.author}</span>
                                 </div>
                                 <div className="flex justify-between items-center">

--- a/lib/articles.ts
+++ b/lib/articles.ts
@@ -4,6 +4,13 @@ import matter from 'gray-matter'
 
 const articlesDirectory = path.join(process.cwd(), 'content/articles')
 
+export interface Author {
+    name: string;
+    role?: string;
+    bio?: string;
+    avatar_url?: string;
+}
+
 export interface ArticleItem {
     id: number
     title: string
@@ -11,6 +18,7 @@ export interface ArticleItem {
     author: string
     description?: string
     date: string
+    coverImage?: string;
     tags?: string[]
 }
 
@@ -27,6 +35,8 @@ export function getAllArticles(): ArticleItem[] {
             const fullPath = path.join(articlesDirectory, fileName)
             const fileContents = fs.readFileSync(fullPath, 'utf8')
             const { data } = matter(fileContents)
+            const coverImage = data.coverImage ? data.coverImage: null
+            const fallbackImage = "https://images.unsplash.com/photo-1523580494863-6f3031224c94?q=80&w=1000"
 
             return {
                 id,
@@ -35,6 +45,7 @@ export function getAllArticles(): ArticleItem[] {
                 author: data.author,
                 description: data.description,
                 date: data.date,
+                coverImage: coverImage || fallbackImage,
                 tags: data.tags,
             } as ArticleItem
         })


### PR DESCRIPTION
This add cover image and author area.
Author is not yet retrieved from authors, but is retrived from /images/speakers folder.
The article content will follow in another PR.